### PR TITLE
adding the ICM20649

### DIFF
--- a/Adafruit_SensorLab.h
+++ b/Adafruit_SensorLab.h
@@ -21,6 +21,7 @@
 #include <Adafruit_DPS310.h>
 #include <Adafruit_FXAS21002C.h>
 #include <Adafruit_FXOS8700.h>
+#include <Adafruit_ICM20649.h>
 #include <Adafruit_ISM330DHCT.h>
 #include <Adafruit_LIS3MDL.h>
 #include <Adafruit_LSM6DS33.h>
@@ -48,6 +49,7 @@ public:
   bool detectDPS310(void);
   bool detectLSM6DS33(void);
   bool detectLSM6DSOX(void);
+  bool detectICM20649(void);
   bool detectISM330DHCT(void);
   bool detectLIS3MDL(void);
   bool detectFXOS8700(void);
@@ -69,6 +71,7 @@ private:
   Adafruit_DPS310 *_dps310 = NULL;
   Adafruit_LSM6DS33 *_lsm6ds33 = NULL;
   Adafruit_LSM6DSOX *_lsm6dsox = NULL;
+  Adafruit_ICM20649 *_icm20649 = NULL;
   Adafruit_ISM330DHCT *_ism330dhct = NULL;
   Adafruit_LIS3MDL *_lis3mdl = NULL;
   Adafruit_FXOS8700 *_fxos8700 = NULL;

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for scientific sensor readings/fusions/manipulations
 category=Sensors
 url=https://github.com/adafruit/Adafruit_SensorLab
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL
+depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit ICM20649


### PR DESCRIPTION
This adds the ICM20649. Tested with the OLED demo, spirit level, and inclinometer demos. The radians/s is better after fixing it in the ICM20649 repo (https://github.com/adafruit/Adafruit_ICM20649/pulls) but it still seems off, showing around .5 rads/sec where a similar demo in the ICM repo shows close to 0