### PR TITLE
added mlx90393 mag support

### DIFF
--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -662,6 +662,43 @@ bool Adafruit_SensorLab::detectBME280(void) {
 
 /**************************************************************************/
 /*!
+    @brief  Detect if we have a valid MLX90393 sensor attached and set
+    the default magnetomer sensor if so
+    @return True if found
+*/
+/**************************************************************************/
+
+bool Adafruit_SensorLab::detectMLX90393(void) {
+	bool addr0C = scanI2C(0x0C);
+	bool addr0D = scanI2C(0x0D);
+	bool addr0E = scanI2C(0x0E);
+	bool addr0F = scanI2C(0x0F);
+	Serial.println("Looking for MLX90393");
+	
+	if (!addr0C && !addr0D && !addr0E && !addr0F) {
+		return false;	// no I2C device that could possibly work found!
+	}
+	
+	_mlx90393 = new Adafruit_MLX90393();
+	
+	if((addr0C && _mlx90393->begin_I2C(0x0C)) ||
+		(addr0D && _mlx90393->begin_I2C(0x0D)) ||
+		(addr0E && _mlx90393->begin_I2C(0x0E)) || 
+		(addr0F && _mlx90393->begin_I2C(0x0F))) {
+			// yay found an MLX90393
+    Serial.println(F("Found a MLX90393 Magnetometer sensor"));
+    if (!magnetometer)
+	  magnetometer = _mlx90393;
+
+    return true;
+	}
+	
+	delete _mlx90393;
+	return false;
+}
+
+/**************************************************************************/
+/*!
     @brief  Look for any known accelerometer-providing sensor on I2C
     @return A pointer to the Adafruit_Sensor device that can be queried
     for sensor events. NULL on failure to find any matching sensor.
@@ -693,7 +730,7 @@ Adafruit_Sensor *Adafruit_SensorLab::getMagnetometer(void) {
     return magnetometer; // we already did this process
   }
   if (detectLIS3MDL() || detectLIS2MDL() || detectFXOS8700() ||
-      detectLSM9DS0()) {
+      detectLSM9DS0() || detectMLX90393()) {
     return magnetometer;
   }
   // Nothing detected

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -669,32 +669,32 @@ bool Adafruit_SensorLab::detectBME280(void) {
 /**************************************************************************/
 
 bool Adafruit_SensorLab::detectMLX90393(void) {
-	bool addr0C = scanI2C(0x0C);
-	bool addr0D = scanI2C(0x0D);
-	bool addr0E = scanI2C(0x0E);
-	bool addr0F = scanI2C(0x0F);
-	Serial.println("Looking for MLX90393");
-	
-	if (!addr0C && !addr0D && !addr0E && !addr0F) {
-		return false;	// no I2C device that could possibly work found!
-	}
-	
-	_mlx90393 = new Adafruit_MLX90393();
-	
-	if((addr0C && _mlx90393->begin_I2C(0x0C)) ||
-		(addr0D && _mlx90393->begin_I2C(0x0D)) ||
-		(addr0E && _mlx90393->begin_I2C(0x0E)) || 
-		(addr0F && _mlx90393->begin_I2C(0x0F))) {
-			// yay found an MLX90393
+  bool addr0C = scanI2C(0x0C);
+  bool addr0D = scanI2C(0x0D);
+  bool addr0E = scanI2C(0x0E);
+  bool addr0F = scanI2C(0x0F);
+  Serial.println("Looking for MLX90393");
+
+  if (!addr0C && !addr0D && !addr0E && !addr0F) {
+    return false; // no I2C device that could possibly work found!
+  }
+
+  _mlx90393 = new Adafruit_MLX90393();
+
+  if ((addr0C && _mlx90393->begin_I2C(0x0C)) ||
+      (addr0D && _mlx90393->begin_I2C(0x0D)) ||
+      (addr0E && _mlx90393->begin_I2C(0x0E)) ||
+      (addr0F && _mlx90393->begin_I2C(0x0F))) {
+    // yay found an MLX90393
     Serial.println(F("Found a MLX90393 Magnetometer sensor"));
     if (!magnetometer)
-	  magnetometer = _mlx90393;
+      magnetometer = _mlx90393;
 
     return true;
-	}
-	
-	delete _mlx90393;
-	return false;
+  }
+
+  delete _mlx90393;
+  return false;
 }
 
 /**************************************************************************/

--- a/Adafruit_SensorLab.h
+++ b/Adafruit_SensorLab.h
@@ -35,6 +35,7 @@
 #include <Adafruit_MPU6050.h>
 #include <Adafruit_MSA301.h>
 #include <Adafruit_Sensor.h>
+#include <Adafruit_MLX90393.h>
 #include <Arduino.h>
 
 /**************************************************************************/
@@ -77,6 +78,7 @@ public:
   bool detectLSM9DS1(void);
   bool detectMPU6050(void);
   bool detectMSA301(void);
+  bool detectMLX90393(void);
 
   static float mapf(float x, float in_min, float in_max, float out_min,
                     float out_max);
@@ -107,6 +109,7 @@ private:
   Adafruit_LSM9DS1 *_lsm9ds1 = NULL;
   Adafruit_MPU6050 *_mpu6050 = NULL;
   Adafruit_MSA301 *_msa301 = NULL;
+  Adafruit_MLX90393 *_mlx90393 = NULL;
 
   Adafruit_Sensor *accelerometer = NULL;
   Adafruit_Sensor *gyroscope = NULL;

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for scientific sensor readings/fusions/manipulations
 category=Sensors
 url=https://github.com/adafruit/Adafruit_SensorLab
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit MSA301, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit ICM20X, Adafruit MPU6050, Adafruit LIS2MDL, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit AHRS, Adafruit Arcada Library, Adafruit Sensor Calibration, Adafruit SHT31 Library, Adafruit APDS9960 Library, Adafruit LPS2X, Adafruit HTS221
+depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit MSA301, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit ICM20X, Adafruit MPU6050, Adafruit LIS2MDL, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit AHRS, Adafruit Arcada Library, Adafruit Sensor Calibration, Adafruit SHT31 Library, Adafruit APDS9960 Library, Adafruit LPS2X, Adafruit HTS221, Adafruit MLX90393


### PR DESCRIPTION
**Adafruit_SensorLab.cpp**
-added a detectMLX90393 method
-modified the getMagnetometer method to include detectMLX90393 condition

**Adafruit_SensorLab.h**
-set the file to include the Adafruit_MLX90393 header file
-added a detectMLX90393 boolean
-added pointer to Adafruit_MLX90393 class, set to NULL

Comments:
-these changes have been tested using the mag_hardiron_simplecal.ino example
