### PR TITLE
Enable configurable addresses for FX devices

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Sensor Lab
-version=0.4.2
+version=0.4.3
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for scientific sensor readings/fusions/manipulations


### PR DESCRIPTION
Integrate support for https://github.com/adafruit/Adafruit_FXOS8700/pull/6 and https://github.com/adafruit/Adafruit_FXAS21002C/pull/9 configurable addresses.

I have tested with the Freescale Freedom board with these devices on it with a Grand Central M4, because those are the boards I have. What is important to note is that this Freescale board seems to not work on the Arduino Due, possibly due to the underlying I2C Wire implementation. The `scanI2C()` method blocks indefinitely, will put in an issue if I can reproduce it separately.