### PR TITLE
Add AHTX0 Sensor Library

### DIFF
--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -780,7 +780,8 @@ Adafruit_Sensor *Adafruit_SensorLab::getTemperatureSensor(void) {
   if (temperature) {
     return temperature; // we already did this process
   }
-  if (detectBMP280() || detectBME280() || detectDPS310() || detectLPS2X() || detectAHTX0()) {
+  if (detectBMP280() || detectBME280() || detectDPS310() || detectLPS2X() ||
+      detectAHTX0()) {
     return temperature;
   }
   // Nothing detected

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -81,8 +81,8 @@ bool Adafruit_SensorLab::detectADXL34X(void) {
 
 /**************************************************************************/
 /*!
-    @brief  Detect if we have a valid AHTX0 (AHT10 & AHT20) sensor attached
-    and sets the default temperature and humidity sensors if so.
+    @brief  Detect if we have a valid AHTX0 (AHT10 & AHT20) sensor
+    attached and sets the default temperature and humidity sensors if so.
     @return True if sensor is detected, False otherwise.
 */
 /**************************************************************************/

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -81,6 +81,35 @@ bool Adafruit_SensorLab::detectADXL34X(void) {
 
 /**************************************************************************/
 /*!
+    @brief  Detect if we have a valid AHTX0 (AHT10 & AHT20) sensor attached
+    and sets the default temperature and humidity sensors if so.
+    @return True if sensor is detected, False otherwise.
+*/
+/**************************************************************************/
+bool Adafruit_SensorLab::detectAHTX0(void) {
+  bool addr38 = scanI2C(0x38);
+
+  if (!addr38) {
+    return false; // not even maybe!
+  }
+
+  _ahtx0 = new Adafruit_AHTX0();
+
+  if (addr38 && _ahtx0->begin()) {
+    // we got one!
+    Serial.println(F("Found an AHT20 Temperature & Humidity Sensor"));
+    if (!humidity)
+      humidity = _ahtx0->getHumiditySensor();
+    if (!temperature)
+      temperature = _ahtx0->getTemperatureSensor();
+    return true;
+  }
+  delete _ahtx0;
+  return false;
+}
+
+/**************************************************************************/
+/*!
     @brief  Detect if we have a valid ADXL34x sensor attached and sets
     the default accelerometer sensor if so
     @return True if found
@@ -309,35 +338,6 @@ bool Adafruit_SensorLab::detectHTS221(void) {
     return true;
   }
   delete _hts221;
-  return false;
-}
-
-/**************************************************************************/
-/*!
-    @brief  Detect if we have a valid AHTX0 (AHT10 & AHT20) sensor attached
-    and sets the default temperature and humidity sensors if so.
-    @return True if sensor is detected, False otherwise.
-*/
-/**************************************************************************/
-bool Adafruit_SensorLab::detectAHTX0(void) {
-  bool addr38 = scanI2C(0x38);
-
-  if (!addr38) {
-    return false; // not even maybe!
-  }
-
-  _ahtx0 = new Adafruit_AHTX0();
-
-  if (addr5f && _ahtx0->aht.begin()) {
-    // we got one!
-    Serial.println(F("Found an AHT20 Temperature & Humidity Sensor"));
-    if (!humidity)
-      humidity = _ahtx0->getHumiditySensor();
-    if (!temperature)
-      temperature = _ahtx0->getTemperatureSensor();
-    return true;
-  }
-  delete _ahtx0;
   return false;
 }
 
@@ -780,7 +780,7 @@ Adafruit_Sensor *Adafruit_SensorLab::getTemperatureSensor(void) {
   if (temperature) {
     return temperature; // we already did this process
   }
-  if (detectBMP280() || detectBME280() || detectDPS310() || detectLPS2X()) {
+  if (detectBMP280() || detectBME280() || detectDPS310() || detectLPS2X() || detectAHTX0()) {
     return temperature;
   }
   // Nothing detected
@@ -798,7 +798,7 @@ Adafruit_Sensor *Adafruit_SensorLab::getHumiditySensor(void) {
   if (humidity) {
     return humidity; // we already did this process
   }
-  if (detectBME280() || detectHTS221()) {
+  if (detectBME280() || detectHTS221() || detectAHTX0()) {
     return humidity;
   }
   // Nothing detected

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -283,6 +283,7 @@ bool Adafruit_SensorLab::detectICM20649(void) {
   delete _icm20649;
   return false;
 }
+
 /**************************************************************************/
 /*!
     @brief  Detect if we have a valid HTS221 sensor attached and sets
@@ -310,6 +311,36 @@ bool Adafruit_SensorLab::detectHTS221(void) {
   delete _hts221;
   return false;
 }
+
+/**************************************************************************/
+/*!
+    @brief  Detect if we have a valid AHTX0 (AHT10 & AHT20) sensor attached
+    and sets the default temperature and humidity sensors if so.
+    @return True if sensor is detected, False otherwise.
+*/
+/**************************************************************************/
+bool Adafruit_SensorLab::detectAHTX0(void) {
+  bool addr38 = scanI2C(0x38);
+
+  if (!addr38) {
+    return false; // not even maybe!
+  }
+
+  _ahtx0 = new Adafruit_AHTX0();
+
+  if (addr5f && _ahtx0->aht.begin()) {
+    // we got one!
+    Serial.println(F("Found an AHT20 Temperature & Humidity Sensor"));
+    if (!humidity)
+      humidity = _ahtx0->getHumiditySensor();
+    if (!temperature)
+      temperature = _ahtx0->getTemperatureSensor();
+    return true;
+  }
+  delete _ahtx0;
+  return false;
+}
+
 /**************************************************************************/
 /*!
     @brief  Detect if we have a valid ISM330DHC sensor attached and sets

--- a/Adafruit_SensorLab.h
+++ b/Adafruit_SensorLab.h
@@ -16,6 +16,7 @@
 #define ADAFRUIT_SENSORLAB_H
 
 #include <Adafruit_ADXL343.h>
+#include <Adafruit_AHTX0.h>
 #include <Adafruit_BME280.h>
 #include <Adafruit_BMP280.h>
 #include <Adafruit_DPS310.h>
@@ -59,6 +60,7 @@ public:
   float calculateAltitude(float currentPressure_hPa,
                           float originPressure_hPa = 1013.25);
   bool detectADXL34X(void);
+  bool detectAHTX0(void);
   bool detectBME280(void);
   bool detectBMP280(void);
   bool detectDPS310(void);
@@ -89,6 +91,7 @@ private:
   TwoWire *_i2c;
 
   Adafruit_ADXL343 *_adxl34x = NULL;
+  Adafruit_AHTX0 *_ahtx0 = NULL;
   Adafruit_BME280 *_bme280 = NULL;
   Adafruit_BMP280 *_bmp280 = NULL;
   Adafruit_DPS310 *_dps310 = NULL;

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ plenty of flash storage :)
 
 
 ## Supported environmental sensors:
+  * AHT10 - Temperature & Humidity
+  * AHT20 - Temperature & Humidity
   * BMP280 - Temperature & Pressure
   * BME280 - Temperature, Humidity & Pressure
   * DSP310 - Temperature & Pressure

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Sensor Lab
-version=0.4.3
+version=0.4.4
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for scientific sensor readings/fusions/manipulations
@@ -7,4 +7,4 @@ paragraph=Arduino library for scientific sensor readings/fusions/manipulations
 category=Sensors
 url=https://github.com/adafruit/Adafruit_SensorLab
 architectures=*
-depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit MSA301, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit ICM20X, Adafruit MPU6050, Adafruit LIS2MDL, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit AHRS, Adafruit Arcada Library, Adafruit Sensor Calibration, Adafruit SHT31 Library, Adafruit APDS9960 Library, Adafruit LPS2X, Adafruit HTS221
+depends=Adafruit Unified Sensor, Adafruit BME280 Library, Adafruit BMP280 Library, Adafruit DPS310, Adafruit ADXL343, Adafruit MSA301, Adafruit Arcada Library, Adafruit FXOS8700, Adafruit FXAS21002C, Adafruit LSM6DS, Adafruit LIS3MDL, Adafruit ICM20X, Adafruit MPU6050, Adafruit LIS2MDL, Adafruit LSM9DS1 Library, Adafruit LSM9DS0 Library, Adafruit AHRS, Adafruit Arcada Library, Adafruit Sensor Calibration, Adafruit SHT31 Library, Adafruit APDS9960 Library, Adafruit LPS2X, Adafruit HTS221, Adafruit AHTX0


### PR DESCRIPTION
Adding support for the [Adafruit AHT10+AHT20 Humidity and Temperature Sensor library](https://github.com/adafruit/Adafruit_AHTX0)

Supported Sensors:
* AHT10
* AHT20

---

Tested on: FunHouse ESP32S2 (AHT20 built-in, default I2C address)

Test Sketch used: `sensorlab_humidity_temp_oled.ino`

Test Output:
```
8:04:00.198 -> Humidity and Temp demo
18:04:00.677 -> Looking for a humidity sensor
18:04:00.677 -> Looking for BME280
18:04:00.748 -> Found an AHT20 Temperature & Humidity Sensor
18:04:00.748 -> ------------------------------------
18:04:00.748 -> Sensor:       AHTx0_H
18:04:00.748 -> Type:         Relative Humidity (%)
18:04:00.748 -> Driver Ver:   1
18:04:00.748 -> Unique ID:    4128
18:04:00.748 -> Min Value:    0.00
18:04:00.748 -> Max Value:    100.00
18:04:00.748 -> Resolution:   2.00
18:04:00.748 -> ------------------------------------
18:04:00.748 -> 
18:04:00.748 -> Looking for a temperature sensor
18:04:00.748 -> ------------------------------------
18:04:00.748 -> Sensor:       AHTx0_T
18:04:00.748 -> Type:         Ambient Temp (C)
18:04:00.748 -> Driver Ver:   1
18:04:00.748 -> Unique ID:    4129
18:04:00.748 -> Min Value:    -40.00
18:04:00.748 -> Max Value:    85.00
18:04:00.748 -> Resolution:   0.30
18:04:00.748 -> ------------------------------------
18:04:00.748 -> 
18:04:00.849 -> Humidity: 40.2 %rH
18:04:00.849 -> Temperature: 22.6 degrees C
18:04:00.849 -> 
18:04:01.015 -> Humidity: 40.3 %rH
18:04:01.015 -> Temperature: 22.7 degrees C
18:04:01.015 -> 
18:04:01.226 -> Humidity: 40.3 %rH
18:04:01.226 -> Temperature: 22.7 degrees C
18:04:01.226 -> 
18:04:01.433 -> Humidity: 40.2 %rH
18:04:01.433 -> Temperature: 22.7 degrees C
```