### PR TITLE
Changed settings on MLX90393 to make it more precise during calibration

### DIFF
--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -526,8 +526,21 @@ bool Adafruit_SensorLab::detectMLX90393(void) {
 
   if ((addr0C && _mlx90393->begin_I2C(0x0C, _i2c)) ||
       (addr18 && _mlx90393->begin_I2C(0x18, _i2c))) {
-    // yay found a MLX90393
+		  
+    // Found an MLX90393!
     Serial.println(F("Found a MLX90393 IMU"));
+	
+	// Set to lowest gain and aim for sensitivity = ~0.3 for X, Y, and Z
+	_mlx90393->setGain(MLX90393_GAIN_1X);
+	_mlx90393->setResolution(MLX90393_X, MLX90393_RES_17);
+	_mlx90393->setResolution(MLX90393_Y, MLX90393_RES_17);
+	_mlx90393->setResolution(MLX90393_Z, MLX90393_RES_16);
+	
+	// Use maximum oversampling for better precision
+	_mlx90393->setOversampling(MLX90393_OSR_3);
+	
+	// Use decent filtering to get better precision with fast sampling
+	_mlx90393->setFilter(MLX90393_FILTER_5);
 
     if (!magnetometer)
       magnetometer = _mlx90393;

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -526,19 +526,19 @@ bool Adafruit_SensorLab::detectMLX90393(void) {
 
   if ((addr0C && _mlx90393->begin_I2C(0x0C, _i2c)) ||
       (addr18 && _mlx90393->begin_I2C(0x18, _i2c))) {
-		  
+
     // Found an MLX90393!
     Serial.println(F("Found a MLX90393 IMU"));
-    
+
     // Set to lowest gain and aim for sensitivity = ~0.3 for X, Y, and Z
     _mlx90393->setGain(MLX90393_GAIN_1X);
     _mlx90393->setResolution(MLX90393_X, MLX90393_RES_17);
     _mlx90393->setResolution(MLX90393_Y, MLX90393_RES_17);
     _mlx90393->setResolution(MLX90393_Z, MLX90393_RES_16);
-    
+
     // Use maximum oversampling for better precision
     _mlx90393->setOversampling(MLX90393_OSR_3);
-    
+
     // Use decent filtering to get better precision with fast sampling
     _mlx90393->setFilter(MLX90393_FILTER_5);
 

--- a/Adafruit_SensorLab.cpp
+++ b/Adafruit_SensorLab.cpp
@@ -529,18 +529,18 @@ bool Adafruit_SensorLab::detectMLX90393(void) {
 		  
     // Found an MLX90393!
     Serial.println(F("Found a MLX90393 IMU"));
-	
-	// Set to lowest gain and aim for sensitivity = ~0.3 for X, Y, and Z
-	_mlx90393->setGain(MLX90393_GAIN_1X);
-	_mlx90393->setResolution(MLX90393_X, MLX90393_RES_17);
-	_mlx90393->setResolution(MLX90393_Y, MLX90393_RES_17);
-	_mlx90393->setResolution(MLX90393_Z, MLX90393_RES_16);
-	
-	// Use maximum oversampling for better precision
-	_mlx90393->setOversampling(MLX90393_OSR_3);
-	
-	// Use decent filtering to get better precision with fast sampling
-	_mlx90393->setFilter(MLX90393_FILTER_5);
+    
+    // Set to lowest gain and aim for sensitivity = ~0.3 for X, Y, and Z
+    _mlx90393->setGain(MLX90393_GAIN_1X);
+    _mlx90393->setResolution(MLX90393_X, MLX90393_RES_17);
+    _mlx90393->setResolution(MLX90393_Y, MLX90393_RES_17);
+    _mlx90393->setResolution(MLX90393_Z, MLX90393_RES_16);
+    
+    // Use maximum oversampling for better precision
+    _mlx90393->setOversampling(MLX90393_OSR_3);
+    
+    // Use decent filtering to get better precision with fast sampling
+    _mlx90393->setFilter(MLX90393_FILTER_5);
 
     if (!magnetometer)
       magnetometer = _mlx90393;


### PR DESCRIPTION
The default settings on the MLX9039 are terribly imprecise and make for poor calibration data. Changed its settings to be less sensitive and faster so that calibration works better.

Before:
![image](https://user-images.githubusercontent.com/5232145/154824691-15e632d7-c56e-49ca-a567-450c9d514acd.png)

After:
![image](https://user-images.githubusercontent.com/5232145/154824704-e5c13b0e-50bb-4913-9ece-f5ee7bf3deee.png)
